### PR TITLE
Resolved resampling functions for support in MedEye3d

### DIFF
--- a/src/Load_and_save.jl
+++ b/src/Load_and_save.jl
@@ -4,10 +4,10 @@ using Dictionaries, Dates, PyCall
 using Accessors, UUIDs
 using ..MedImage_data_struct
 using ..MedImage_data_struct:MedImage
-
+using ..Utils
 export load_images
 export load_image
-
+export update_voxel_and_spatial_data
 
 """
 helper function for dicom #1
@@ -171,9 +171,9 @@ end
 function update_voxel_and_spatial_data(old_image::MedImage, new_voxel_data::AbstractArray, new_origin, new_spacing, new_direction)
 
   res = @set old_image.voxel_data = new_voxel_data
-  res = @set res.origin = ensure_tuple(new_origin)
-  res = @set res.spacing = ensure_tuple(new_spacing)
-  res = @set res.direction = ensure_tuple(new_direction)
+  res = @set res.origin = Utils.ensure_tuple(new_origin)
+  res = @set res.spacing = Utils.ensure_tuple(new_spacing)
+  res = @set res.direction = Utils.ensure_tuple(new_direction)
   # voxel_data=new_voxel_data
   # origin=new_origin
   # spacing=new_spacing

--- a/src/Load_and_save.jl
+++ b/src/Load_and_save.jl
@@ -80,7 +80,7 @@ function infer_modality(image)
         return MedImage_data_struct.PET_type
     end
 
-    return "Unknown"
+    return MedImage_data_struct.CT_type
 end
 
 
@@ -98,6 +98,7 @@ function load_images(path::String)::Array{MedImage}
   else
     sitk = pyimport("SimpleITK")
     itk_nifti_image = sitk.ReadImage(path)
+    itk_nifti_image = sitk.DICOMOrient(itk_nifti_image,"LPS")
     origin = itk_nifti_image.GetOrigin()
     # origin = set_origin_for_nifti_file(sform_qform_similar, nifti_image_struct.sto_xyz)
     spacing = itk_nifti_image.GetSpacing()  #set_spacing_for_nifti_files([nifti_image_struct.dx, nifti_image_struct.dy,nifti_image_struct.dz])

--- a/src/MedImages.jl
+++ b/src/MedImages.jl
@@ -8,12 +8,12 @@ export Utils
 
 
 include("MedImage_data_struct.jl")
-include("Load_and_save.jl")
+include("Orientation_dicts.jl")
 include("Utils.jl")
+include("Load_and_save.jl")
 include("Basic_transformations.jl")
-include("Resample_to_target.jl")
 include("Spatial_metadata_change.jl")
-# include("Orientation_dicts.jl")
+include("Resample_to_target.jl")
 # include("Brute_force_orientation.jl")
 include("HDF5_manag.jl")
 end #MedImages

--- a/src/Orientation_dicts.jl
+++ b/src/Orientation_dicts.jl
@@ -1,4 +1,5 @@
 module Orientation_dicts
+using ..MedImage_data_struct
 export orientation_enum_to_string, string_to_orientation_enum, orientation_dict_enum_to_number, number_to_enum_orientation_dict, orientation_pair_to_operation_dict
 orientation_enum_to_string = Dict(
 # ORIENTATION_RIP=>"RIP",
@@ -17,14 +18,14 @@ orientation_enum_to_string = Dict(
 # ORIENTATION_ILA=>"ILA",
 # ORIENTATION_SRA=>"SRA",
 # ORIENTATION_SLA=>"SLA",
-ORIENTATION_RPI=>"RPI",
-ORIENTATION_LPI=>"LPI",
-ORIENTATION_RAI=>"RAI",
-ORIENTATION_LAI=>"LAI",
-ORIENTATION_RPS=>"RPS",
-ORIENTATION_LPS=>"LPS",
-ORIENTATION_RAS=>"RAS",
-ORIENTATION_LAS=>"LAS",
+MedImage_data_struct.ORIENTATION_RPI=>"RPI",
+MedImage_data_struct.ORIENTATION_LPI=>"LPI",
+MedImage_data_struct.ORIENTATION_RAI=>"RAI",
+MedImage_data_struct.ORIENTATION_LAI=>"LAI",
+MedImage_data_struct.ORIENTATION_RPS=>"RPS",
+MedImage_data_struct.ORIENTATION_LPS=>"LPS",
+MedImage_data_struct.ORIENTATION_RAS=>"RAS",
+MedImage_data_struct.ORIENTATION_LAS=>"LAS",
 # ORIENTATION_PRI=>"PRI",
 # ORIENTATION_PLI=>"PLI",
 # ORIENTATION_ARI=>"ARI",
@@ -43,11 +44,11 @@ ORIENTATION_LAS=>"LAS",
 # ORIENTATION_SAL=>"SAL",
 # ORIENTATION_PIR=>"PIR",
 # ORIENTATION_PSR=>"PSR",
-# ORIENTATION_AIR=>"AIR", 
+# ORIENTATION_AIR=>"AIR",
 # ORIENTATION_ASR=>"ASR",
 # ORIENTATION_PIL=>"PIL",
 # ORIENTATION_PSL=>"PSL",
-# ORIENTATION_AIL=>"AIL", 
+# ORIENTATION_AIL=>"AIL",
 # ORIENTATION_ASL=>"ASL"
 )
 
@@ -58,15 +59,15 @@ orientation_dict_enum_to_number=Dict(
     # ,ORIENTATION_AIL => (0.0, 0.0, 1.0, -1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
     # ,ORIENTATION_PSR => (0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
     # ,ORIENTATION_ASL => (0.0, 0.0, 1.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
-    ORIENTATION_RAS => (-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0)
+    MedImage_data_struct.ORIENTATION_RAS => (-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0)
     # ,ORIENTATION_AIR => (0.0, 0.0, -1.0, -1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
     # ,ORIENTATION_LIP => (1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0)
-    ,ORIENTATION_LAS => (1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0)
+    ,MedImage_data_struct.ORIENTATION_LAS => (1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0)
     # ,ORIENTATION_SPL => (0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0)
     # ,ORIENTATION_PLS => (0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
     # ,ORIENTATION_ARI => (0.0, -1.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, -1.0)
-    ,ORIENTATION_LPI => (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, -1.0)
-    ,ORIENTATION_RAI => (-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0)
+    ,MedImage_data_struct.ORIENTATION_LPI => (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, -1.0)
+    ,MedImage_data_struct.ORIENTATION_RAI => (-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0)
     # ,ORIENTATION_IRP => (0.0, -1.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0)
     # ,ORIENTATION_SRP => (0.0, -1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0)
     # ,ORIENTATION_ALI => (0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, -1.0)
@@ -84,21 +85,21 @@ orientation_dict_enum_to_number=Dict(
     # ,ORIENTATION_RSA => (-1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0)
     # ,ORIENTATION_IPR => (0.0, 0.0, -1.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0)
     # ,ORIENTATION_RIP => (-1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0)
-    ,ORIENTATION_LAI => (1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0)
+    ,MedImage_data_struct.ORIENTATION_LAI => (1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0)
     # ,ORIENTATION_PLI => (0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, -1.0)
     # ,ORIENTATION_LSA => (1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0)
     # ,ORIENTATION_SPR => (0.0, 0.0, -1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0)
     # ,ORIENTATION_IAL => (0.0, 0.0, 1.0, 0.0, -1.0, 0.0, -1.0, 0.0, 0.0)
     # ,ORIENTATION_SAL => (0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0)
     # ,ORIENTATION_ARS => (0.0, -1.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
-    ,ORIENTATION_LPS => (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+    ,MedImage_data_struct.ORIENTATION_LPS => (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
     # ,ORIENTATION_LSP => (1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0)
     # ,ORIENTATION_RIA => (-1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, -1.0, 0.0)
     # ,ORIENTATION_ILA => (0.0, 1.0, 0.0, 0.0, 0.0, -1.0, -1.0, 0.0, 0.0)
     # ,ORIENTATION_SRA => (0.0, -1.0, 0.0, 0.0, 0.0, -1.0, 1.0, 0.0, 0.0)
-    ,ORIENTATION_RPS => (-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+    ,MedImage_data_struct.ORIENTATION_RPS => (-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
     # ,ORIENTATION_SAR => (0.0, 0.0, -1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0)
-    ,ORIENTATION_RPI => (-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, -1.0)
+    ,MedImage_data_struct.ORIENTATION_RPI => (-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, -1.0)
     # ,ORIENTATION_LIA => (1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, -1.0, 0.0)
     # ,ORIENTATION_IPL => (0.0, 0.0, 1.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0)
     # ,ORIENTATION_SLP => (0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0)
@@ -106,69 +107,86 @@ orientation_dict_enum_to_number=Dict(
 number_to_enum_orientation_dict = Dict(value => key for (key, value) in orientation_dict_enum_to_number)
 
 
-orientation_pair_to_operation_dict =Dict((ORIENTATION_RAI, ORIENTATION_LPS) => (Int64[], [1, 2, 3], [[1, 1, 1, -1], [2, 2, 2, -1], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RPI, ORIENTATION_RPS) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_LPI, ORIENTATION_LAS) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, 1], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_LAS, ORIENTATION_RPI) => (Int64[], [1, 2, 3], [[1, 1, 1, 1], [2, 2, 2, -1], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_LAS, ORIENTATION_RPS) => (Int64[], [1, 2], [[1, 1, 1, 1], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAI, ORIENTATION_RAI) => (Int64[], [1], [[1, 1, 1, 1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAI, ORIENTATION_LPI) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPI, ORIENTATION_RAS) => (Int64[], [1, 2, 3], [[1, 1, 1, 1], [2, 2, 2, 1], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RPS, ORIENTATION_RAI) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, 1], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_LPS, ORIENTATION_LAI) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, 1], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_RAI, ORIENTATION_LAS) => (Int64[], [1, 3], [[1, 1, 1, -1], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RPS, ORIENTATION_LPI) => (Int64[], [1, 3], [[1, 1, 1, -1], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_LAI, ORIENTATION_RPI) => (Int64[], [1, 2], [[1, 1, 1, 1], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RPS, ORIENTATION_RPI) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_RAI, ORIENTATION_RAS) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_LAI, ORIENTATION_RPS) => (Int64[], [1, 2, 3], [[1, 1, 1, 1], [2, 2, 2, -1], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RPS, ORIENTATION_RPS) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPS, ORIENTATION_RAI) => (Int64[], [1, 2, 3], [[1, 1, 1, 1], [2, 2, 2, 1], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_LPS, ORIENTATION_LPI) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_LPI, ORIENTATION_LAI) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RAS, ORIENTATION_LPS) => (Int64[], [1, 2], [[1, 1, 1, -1], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RPI, ORIENTATION_LPS) => (Int64[], [1, 3], [[1, 1, 1, -1], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_LPS, ORIENTATION_RPI) => (Int64[], [1, 3], [[1, 1, 1, 1], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_RAI, ORIENTATION_LAI) => (Int64[], [1], [[1, 1, 1, -1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPS, ORIENTATION_RPS) => (Int64[], [1], [[1, 1, 1, 1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAS, ORIENTATION_LPS) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RAS, ORIENTATION_LAS) => (Int64[], [1], [[1, 1, 1, -1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPI, ORIENTATION_RAI) => (Int64[], [1, 2], [[1, 1, 1, 1], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPI, ORIENTATION_LPI) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RPI, ORIENTATION_LAS) => (Int64[], [1, 2, 3], [[1, 1, 1, -1], [2, 2, 2, 1], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RAS, ORIENTATION_RAS) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPI, ORIENTATION_RPI) => (Int64[], [1], [[1, 1, 1, 1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAS, ORIENTATION_LAS) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RAI, ORIENTATION_RAI) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAI, ORIENTATION_LPS) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, -1], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RPI, ORIENTATION_RAS) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, 1], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_LPI, ORIENTATION_RPS) => (Int64[], [1, 3], [[1, 1, 1, 1], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RAI, ORIENTATION_LPI) => (Int64[], [1, 2], [[1, 1, 1, -1], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RPS, ORIENTATION_LPS) => (Int64[], [1], [[1, 1, 1, -1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAS, ORIENTATION_RAS) => (Int64[], [1], [[1, 1, 1, 1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RAI, ORIENTATION_RPI) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAI, ORIENTATION_LAS) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RAI, ORIENTATION_RPS) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, -1], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RAS, ORIENTATION_LAI) => (Int64[], [1, 3], [[1, 1, 1, -1], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_RPS, ORIENTATION_LAS) => (Int64[], [1, 2], [[1, 1, 1, -1], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPS, ORIENTATION_LPS) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RPI, ORIENTATION_LAI) => (Int64[], [1, 2], [[1, 1, 1, -1], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAI, ORIENTATION_RAS) => (Int64[], [1, 3], [[1, 1, 1, 1], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_RPS, ORIENTATION_RAS) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAS, ORIENTATION_LAI) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_RAS, ORIENTATION_RAI) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_LPS, ORIENTATION_LAS) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RAS, ORIENTATION_LPI) => (Int64[], [1, 2, 3], [[1, 1, 1, -1], [2, 2, 2, -1], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_RPI, ORIENTATION_RAI) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RPI, ORIENTATION_LPI) => (Int64[], [1], [[1, 1, 1, -1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPI, ORIENTATION_LPS) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
-,(ORIENTATION_LAI, ORIENTATION_LAI) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LPS, ORIENTATION_RAS) => (Int64[], [1, 2], [[1, 1, 1, 1], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RAS, ORIENTATION_RPI) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, -1], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_LAS, ORIENTATION_LPI) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, -1], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_RPS, ORIENTATION_LAI) => (Int64[], [1, 2, 3], [[1, 1, 1, -1], [2, 2, 2, 1], [3, 3, 3, 1]], [1, 2, 3])
-,(ORIENTATION_RAS, ORIENTATION_RPS) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_RPI, ORIENTATION_RPI) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
-,(ORIENTATION_LAS, ORIENTATION_RAI) => (Int64[], [1, 3], [[1, 1, 1, 1], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3]))
+orientation_pair_to_operation_dict =Dict((MedImage_data_struct.ORIENTATION_RAI, MedImage_data_struct.ORIENTATION_LPS) => (Int64[], [1, 2, 3], [[1, 1, 1, -1], [2, 2, 2, -1], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPI, MedImage_data_struct.ORIENTATION_RPS) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPI, MedImage_data_struct.ORIENTATION_LAS) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, 1], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAS, MedImage_data_struct.ORIENTATION_RPI) => (Int64[], [1, 2, 3], [[1, 1, 1, 1], [2, 2, 2, -1], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAS, MedImage_data_struct.ORIENTATION_RPS) => (Int64[], [1, 2], [[1, 1, 1, 1], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAI, MedImage_data_struct.ORIENTATION_RAI) => (Int64[], [1], [[1, 1, 1, 1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAI, MedImage_data_struct.ORIENTATION_LPI) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPI, MedImage_data_struct.ORIENTATION_RAS) => (Int64[], [1, 2, 3], [[1, 1, 1, 1], [2, 2, 2, 1], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPS, MedImage_data_struct.ORIENTATION_RAI) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, 1], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPS, MedImage_data_struct.ORIENTATION_LAI) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, 1], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAI, MedImage_data_struct.ORIENTATION_LAS) => (Int64[], [1, 3], [[1, 1, 1, -1], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPS, MedImage_data_struct.ORIENTATION_LPI) => (Int64[], [1, 3], [[1, 1, 1, -1], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAI, MedImage_data_struct.ORIENTATION_RPI) => (Int64[], [1, 2], [[1, 1, 1, 1], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPS, MedImage_data_struct.ORIENTATION_RPI) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAI, MedImage_data_struct.ORIENTATION_RAS) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAI, MedImage_data_struct.ORIENTATION_RPS) => (Int64[], [1, 2, 3], [[1, 1, 1, 1], [2, 2, 2, -1], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPS, MedImage_data_struct.ORIENTATION_RPS) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPS, MedImage_data_struct.ORIENTATION_RAI) => (Int64[], [1, 2, 3], [[1, 1, 1, 1], [2, 2, 2, 1], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPS, MedImage_data_struct.ORIENTATION_LPI) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPI, MedImage_data_struct.ORIENTATION_LAI) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAS, MedImage_data_struct.ORIENTATION_LPS) => (Int64[], [1, 2], [[1, 1, 1, -1], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPI, MedImage_data_struct.ORIENTATION_LPS) => (Int64[], [1, 3], [[1, 1, 1, -1], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPS, MedImage_data_struct.ORIENTATION_RPI) => (Int64[], [1, 3], [[1, 1, 1, 1], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAI, MedImage_data_struct.ORIENTATION_LAI) => (Int64[], [1], [[1, 1, 1, -1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPS, MedImage_data_struct.ORIENTATION_RPS) => (Int64[], [1], [[1, 1, 1, 1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAS, MedImage_data_struct.ORIENTATION_LPS) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAS, MedImage_data_struct.ORIENTATION_LAS) => (Int64[], [1], [[1, 1, 1, -1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPI, MedImage_data_struct.ORIENTATION_RAI) => (Int64[], [1, 2], [[1, 1, 1, 1], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPI, MedImage_data_struct.ORIENTATION_LPI) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPI, MedImage_data_struct.ORIENTATION_LAS) => (Int64[], [1, 2, 3], [[1, 1, 1, -1], [2, 2, 2, 1], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAS, MedImage_data_struct.ORIENTATION_RAS) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPI, MedImage_data_struct.ORIENTATION_RPI) => (Int64[], [1], [[1, 1, 1, 1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAS, MedImage_data_struct.ORIENTATION_LAS) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAI, MedImage_data_struct.ORIENTATION_RAI) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAI, MedImage_data_struct.ORIENTATION_LPS) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, -1], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPI, MedImage_data_struct.ORIENTATION_RAS) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, 1], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPI, MedImage_data_struct.ORIENTATION_RPS) => (Int64[], [1, 3], [[1, 1, 1, 1], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAI, MedImage_data_struct.ORIENTATION_LPI) => (Int64[], [1, 2], [[1, 1, 1, -1], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPS, MedImage_data_struct.ORIENTATION_LPS) => (Int64[], [1], [[1, 1, 1, -1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAS, MedImage_data_struct.ORIENTATION_RAS) => (Int64[], [1], [[1, 1, 1, 1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAI, MedImage_data_struct.ORIENTATION_RPI) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAI, MedImage_data_struct.ORIENTATION_LAS) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAI, MedImage_data_struct.ORIENTATION_RPS) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, -1], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAS, MedImage_data_struct.ORIENTATION_LAI) => (Int64[], [1, 3], [[1, 1, 1, -1], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPS, MedImage_data_struct.ORIENTATION_LAS) => (Int64[], [1, 2], [[1, 1, 1, -1], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPS, MedImage_data_struct.ORIENTATION_LPS) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPI, MedImage_data_struct.ORIENTATION_LAI) => (Int64[], [1, 2], [[1, 1, 1, -1], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAI, MedImage_data_struct.ORIENTATION_RAS) => (Int64[], [1, 3], [[1, 1, 1, 1], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPS, MedImage_data_struct.ORIENTATION_RAS) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAS, MedImage_data_struct.ORIENTATION_LAI) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAS, MedImage_data_struct.ORIENTATION_RAI) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPS, MedImage_data_struct.ORIENTATION_LAS) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAS, MedImage_data_struct.ORIENTATION_LPI) => (Int64[], [1, 2, 3], [[1, 1, 1, -1], [2, 2, 2, -1], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPI, MedImage_data_struct.ORIENTATION_RAI) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPI, MedImage_data_struct.ORIENTATION_LPI) => (Int64[], [1], [[1, 1, 1, -1], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPI, MedImage_data_struct.ORIENTATION_LPS) => (Int64[], [3], [[1, 3, 1, 0], [1, 3, 2, 0], [3, 3, 3, -1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAI, MedImage_data_struct.ORIENTATION_LAI) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LPS, MedImage_data_struct.ORIENTATION_RAS) => (Int64[], [1, 2], [[1, 1, 1, 1], [2, 2, 2, 1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAS, MedImage_data_struct.ORIENTATION_RPI) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, -1], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAS, MedImage_data_struct.ORIENTATION_LPI) => (Int64[], [2, 3], [[1, 3, 1, 0], [2, 2, 2, -1], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPS, MedImage_data_struct.ORIENTATION_LAI) => (Int64[], [1, 2, 3], [[1, 1, 1, -1], [2, 2, 2, 1], [3, 3, 3, 1]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RAS, MedImage_data_struct.ORIENTATION_RPS) => (Int64[], [2], [[1, 3, 1, 0], [2, 2, 2, -1], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_RPI, MedImage_data_struct.ORIENTATION_RPI) => (Int64[], Int64[], [[1, 3, 1, 0], [1, 3, 2, 0], [1, 3, 3, 0]], [1, 2, 3])
+,(MedImage_data_struct.ORIENTATION_LAS, MedImage_data_struct.ORIENTATION_RAI) => (Int64[], [1, 3], [[1, 1, 1, 1], [1, 3, 2, 0], [3, 3, 3, 1]], [1, 2, 3]))
 
 end
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/Resample_to_target.jl
+++ b/src/Resample_to_target.jl
@@ -2,7 +2,7 @@ module Resample_to_target
 using Interpolations
 using Statistics
 
-using ..MedImage_data_struct, ..Utils
+using ..MedImage_data_struct, ..Utils, ..Orientation_dicts, ..Spatial_metadata_change, ..Load_and_save
 export resample_to_image,  scale
 
 """
@@ -39,9 +39,9 @@ function resample_to_image(im_fixed::MedImage, im_moving::MedImage, interpolator
         value_to_extrapolate=median(corners)
     end
 
-    
+
     # get direction from one and set it to other
-    im_moving=change_orientation(im_moving,number_to_enum_orientation_dict[im_fixed.direction])
+    im_moving=Spatial_metadata_change.change_orientation(im_moving,Orientation_dicts.number_to_enum_orientation_dict[im_fixed.direction])
 
     # Calculate the transformation from moving image space to fixed image space
     old_spacing = im_moving.spacing
@@ -67,7 +67,7 @@ function resample_to_image(im_fixed::MedImage, im_moving::MedImage, interpolator
     # new_voxel_data=cast_to_array_b_type(new_voxel_data,im_fixed.voxel_data)
 
 
-    new_im =update_voxel_and_spatial_data(im_moving, new_voxel_data
+    new_im =Load_and_save.update_voxel_and_spatial_data(im_moving, new_voxel_data
     ,im_fixed.origin,new_spacing,im_fixed.direction)
 
 
@@ -103,7 +103,7 @@ end
 # get 4 dimensional array of cartesian indicies of a 3 dimensional array
 # thats size is passed as an argument dims
 # """
-# function get_base_indicies_arr(dims)    
+# function get_base_indicies_arr(dims)
 #     indices = CartesianIndices(dims)
 #     # indices=collect.(Tuple.(collect(indices)))
 #     indices=Tuple.(collect(indices))

--- a/src/Spatial_metadata_change.jl
+++ b/src/Spatial_metadata_change.jl
@@ -1,8 +1,8 @@
 module Spatial_metadata_change
 using Interpolations
-using ..MedImage_data_struct, ..Utils
+using ..MedImage_data_struct, ..Utils, ..Orientation_dicts, ..Load_and_save
 
-
+export change_orientation, resample_to_spacing
 """
 given a MedImage object and desired spacing (spacing) return the MedImage object with the new spacing
 """
@@ -32,7 +32,7 @@ function resample_to_spacing(im::MedImage, new_spacing::Tuple{Float64,Float64,Fl
 
 
     # Create the new MedImage object
-    new_im = update_voxel_and_spatial_data(im, new_voxel_data, im.origin, new_spacing, im.direction)
+    new_im = Load_and_save.update_voxel_and_spatial_data(im, new_voxel_data, im.origin, new_spacing, im.direction)
 
     return new_im
 end#resample_to_spacing
@@ -48,8 +48,8 @@ end#resample_to_spacing
 given a MedImage object and desired orientation encoded as 3 letter string (like RAS or LPS) return the MedImage object with the new orientation
 """
 function change_orientation(im::MedImage, new_orientation::Orientation_code)::MedImage
-    old_orientation = number_to_enum_orientation_dict[im.direction]
-    reorient_operation = orientation_pair_to_operation_dict[(old_orientation, new_orientation)]
+    old_orientation = Orientation_dicts.number_to_enum_orientation_dict[im.direction]
+    reorient_operation = Orientation_dicts.orientation_pair_to_operation_dict[(old_orientation, new_orientation)]
     return change_orientation_main(im, new_orientation, reorient_operation)
 end#change_orientation
 
@@ -78,7 +78,7 @@ function change_orientation_main(im::MedImage, new_orientation::Orientation_code
     end
 
 
-    # first we need to permute the voxel data to match the desired orientation 
+    # first we need to permute the voxel data to match the desired orientation
     im_voxel_data = copy(im.voxel_data)
     if (length(perm) > 0)
         im_voxel_data = permutedims(im_voxel_data, (perm[1], perm[2], perm[3]))
@@ -99,7 +99,7 @@ function change_orientation_main(im::MedImage, new_orientation::Orientation_code
     st = spacing_transforms
     sp = im.spacing
     new_spacing = (sp[st[1]], sp[st[2]], sp[st[3]])
-    new_im = update_voxel_and_spatial_data(im, im_voxel_data, res_origin, new_spacing, orientation_dict_enum_to_number[new_orientation])
+    new_im = Load_and_save.update_voxel_and_spatial_data(im, im_voxel_data, res_origin, new_spacing, orientation_dict_enum_to_number[new_orientation])
 
     # print("\n res_origin $(res_origin) \n")
     return new_im


### PR DESCRIPTION
please review the ranges in Utils.jl file in src, under the interpolate_my function, 
previously the range A_x1 and so on gave errors, but in this PR they have been commented out with the appropriate ranges.


    A_x1 = 1:input_array_spacing[1]:(1 + input_array_spacing[1] * (old_size[1] - 1))
    A_x2 = 1:input_array_spacing[2]:(1 + input_array_spacing[2] * (old_size[2] - 1))
    A_x3 = 1:input_array_spacing[3]:(1 + input_array_spacing[3] * (old_size[3] - 1))

these are the correct ranges ^
